### PR TITLE
base: Run the builder in strict mode, too

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -306,6 +306,7 @@ in
 
             # Become a fake "root" in a new namespace so we can bind mount sources
             ${pkgs.toybox}/bin/cat << 'EOF' | ${pkgs.util-linux}/bin/unshare -m -r ${pkgs.runtimeShell}
+            set -e -o pipefail
             source $stdenv/setup
             genericBuild
             EOF


### PR DESCRIPTION
Fixes the derivation incorrectly "succeeding" when the build has actually failed, for example due to running out of memory.

One situation where this is relevant is [described here](https://github.com/nix-community/robotnix/pull/226#issuecomment-2026910264). It's unclear why this manifests only with the nixpkgs bump.