### PR TITLE
Bump nixpkgs to 23.11, android-nixpkgs to latest and remove nixpkgsUnstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "androidPkgs": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1638562808,
-        "narHash": "sha256-nnGyBugMQo9WweTgpfPbJu0fHnRtxvsPQ9el2D3wPrY=",
+        "lastModified": 1711829704,
+        "narHash": "sha256-y1ii2SZKesn4wwqn/7g9SN1oBk0t7piQhGmijVBGXfI=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "a191ab6adb019b09d3bb919bb98dca31d83519d5",
+        "rev": "b8cae01d03eb9ded03c00fa1eeef7d448a46d77f",
         "type": "github"
       },
       "original": {
@@ -22,12 +22,19 @@
       }
     },
     "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "androidPkgs",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1637575296,
-        "narHash": "sha256-ZY8YR5u8aglZPe27+AJMnPTG6645WuavB+w0xmhTarw=",
+        "lastModified": 1711099426,
+        "narHash": "sha256-HzpgM/wc3aqpnHJJ2oDqPBkNsqWbW0WfWUO8lKu8nGk=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "0e56ef21ba1a717169953122c7415fa6a8cd2618",
+        "rev": "2d45b54ca4a183f2fdcf4b19c895b64fbf620ee8",
         "type": "github"
       },
       "original": {
@@ -37,12 +44,33 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -53,27 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637841632,
-        "narHash": "sha256-QYqiKHdda0EOnLGQCHE+GluD/Lq2EJj4hVTooPM55Ic=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73369f8d0864854d1acfa7f1e6217f7d6b6e3fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgsUnstable": {
-      "locked": {
-        "lastModified": 1638376152,
-        "narHash": "sha256-ucgLpVqhFnClH7YRUHBHnmiOd82RZdFR3XJt36ks5fE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6daa4a5c045d40e6eae60a3b6e427e8700f1c07f",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -85,16 +97,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1638371214,
-        "narHash": "sha256-0kE6KhgH7n0vyuX4aUoGsGIQOqjIx2fJavpCWtn73rc=",
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a640d8394f34714578f3e6335fc767d0755d78f9",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-21.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -102,8 +114,37 @@
     "root": {
       "inputs": {
         "androidPkgs": "androidPkgs",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgsUnstable": "nixpkgsUnstable"
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Build Android (AOSP) using Nix";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
-    nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     androidPkgs.url = "github:tadfisher/android-nixpkgs/stable";
   };
 
@@ -38,7 +37,8 @@
         wget
 
         # For chromium updater script
-        python2 cipd git
+        # python2
+        cipd git
 
         cachix
       ];

--- a/modules/envpackages.nix
+++ b/modules/envpackages.nix
@@ -18,6 +18,7 @@ in
       lsof
       m4
       ncurses5
+      libxcrypt-legacy
       openssl # Used in avbtool
       psmisc # for "fuser", "pstree"
       rsync

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -11,14 +11,11 @@
   ... }@args:
 
 let
-  inherit (inputs) nixpkgs nixpkgsUnstable androidPkgs;
+  inherit (inputs) nixpkgs androidPkgs;
 in nixpkgs.legacyPackages.x86_64-linux.appendOverlays [
   (self: super: {
     androidPkgs.packages = androidPkgs.packages.x86_64-linux;
     androidPkgs.sdk = androidPkgs.sdk.x86_64-linux;
-
-    inherit (nixpkgsUnstable.legacyPackages.x86_64-linux)
-      diffoscope;
   })
   (import ./overlay.nix)
 ]

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -27,7 +27,10 @@ self: super: {
 
   fetchgerritpatchset = super.callPackage ./fetchgerritpatchset {};
 
-  fetchgit = super.callPackage ./fetchgit {};
+  # TODO cleanup once fetchgit is overridable upstream
+  fetchgit = args: ((super.lib.makeOverridable super.fetchgit) args).overrideAttrs (old: {
+    impureEnvVars = old.impureEnvVars or [ ] ++ [ "ROBOTNIX_GIT_MIRRORS" ];
+  });
   nix-prefetch-git = super.callPackage ./fetchgit/nix-prefetch-git.nix {};
 
   ###


### PR DESCRIPTION
This commit bumps nixpkgs to 23.11, while incorporating small changes to ensure everything works.
At the same time, nixpkgsUnstable has been removed as it does not seem to be needed anymore.
android-nixpkgs has been bumped to the latest version as well.

`LD_LIBRARY_PATH` paths has been added to buildFHSUSerEnv, because of upstream changes. Please see the following information if curious.

https://github.com/NixOS/nixpkgs/issues/103648
https://github.com/NixOS/nixpkgs/issues/112266
https://github.com/NixOS/nixpkgs/issues/262775
https://github.com/NixOS/nixpkgs/pull/263201
https://github.com/NixOS/nixpkgs/pull/278361

Successfully build image for FP4 using flavor LineageOS. Haven't flashed image however.

Unsure if robotnix should target nixos-unstable, instead of nixos-23.11. But this can change in the future, as the most important aspect was getting nixpkgs updated past a 3 year old version.

There are still some things that needs to be done in this PR, e.g. there is quite some Python2 that should maybe be changed to Python3 (if possible), or it could be done in another PR? Unsure. WIP, give recommendations and thoughts :)

EDIT: Thanks to @CyberShadow for doing the groundwork for the minimal changes required for bumping to Python3 + newer fetchgit :)