### PR TITLE
generateKeysScript: Fix build of android-key-tools

### DIFF
--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -209,7 +209,7 @@ in
           ${config.source.dirs."system/extras".src}/verity/generate_verity_key.c \
           ${config.source.dirs."system/core".src}/libcrypto_utils/android_pubkey.c${lib.optionalString (config.androidVersion >= 12) "pp"} \
           -I ${config.source.dirs."system/core".src}/libcrypto_utils/include/ \
-          -I ${pkgs.boringssl}/include ${pkgs.boringssl}/lib/libssl.a ${pkgs.boringssl}/lib/libcrypto.a -lpthread
+          -I ${pkgs.boringssl.dev}/include ${pkgs.boringssl}/lib/libssl.a ${pkgs.boringssl}/lib/libcrypto.a -lpthread
 
         cp ${config.source.dirs."external/avb".src}/avbtool $out/bin/avbtool
 


### PR DESCRIPTION
The build of generate_verity_key because openssl/rsa.h header could not be found, fix the issue by pointing into boringssl.dev package.