### PR TITLE
signing: Add missing APEX keys for Android 13

### DIFF
--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -137,6 +137,8 @@ in
         "appsearch" "art" "art.debug" "art.host" "art.testing" "compos" "geotz"
         "scheduling" "support.apexer" "tethering.inprocess" "virt"
         "vndk.current.on_vendor" "vndk.v30"
+      ] ++ lib.optionals (config.androidVersion >= 13) [
+        "adservices" "btservices" "ondevicepersonalization" "uwb"
       ]
     );
 


### PR DESCRIPTION
Add missing APEX signing keys for Android 13. I previously missed adding these because LineageOS builds were using APEX flattening