### PR TITLE
Add support for signing target files in Android 14

### DIFF
--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -137,6 +137,8 @@ in
         "appsearch" "art" "art.debug" "art.host" "art.testing" "compos" "geotz"
         "scheduling" "support.apexer" "tethering.inprocess" "virt"
         "vndk.current.on_vendor" "vndk.v30"
+      ] ++ lib.optionals (config.androidVersion >= 13) [
+        "adservices" "btservices" "ondevicepersonalization" "uwb"
       ]
     );
 

--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -212,6 +212,16 @@ in
 
     build.generateKeysScript = let
       # Get a bunch of utilities to generate keys
+
+      # avbtool has been renamed to avbtool.py
+      # History about the change:
+      # * Android 10: There's only avbtool
+      # * Android 11: Adds a symlink avbtool.py, which points to avbtool
+      # * Android 12: Swaps the two above, now there's a symlink called avbtool
+      #               which points to avbtool.py
+      # * Android 14: Now there's only avbtool.py, the avbtool symlink has been
+      #               removed
+      avbtoolFilename = if config.androidVersion <= 10 then "avbtool" else "avbtool.py";
       keyTools = pkgs.runCommandCC "android-key-tools" { buildInputs = [ (if config.androidVersion >= 12 then pkgs.python3 else pkgs.python2) ]; } ''
         mkdir -p $out/bin
 
@@ -224,7 +234,7 @@ in
           -I ${config.source.dirs."system/core".src}/libcrypto_utils/include/ \
           -I ${pkgs.boringssl.dev}/include ${pkgs.boringssl}/lib/libssl.a ${pkgs.boringssl}/lib/libcrypto.a -lpthread
 
-        cp ${config.source.dirs."external/avb".src}/avbtool $out/bin/avbtool
+        cp ${config.source.dirs."external/avb".src}/${avbtoolFilename} $out/bin/avbtool
 
         patchShebangs $out/bin
       '';

--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -139,6 +139,9 @@ in
         "vndk.current.on_vendor" "vndk.v30"
       ] ++ lib.optionals (config.androidVersion >= 13) [
         "adservices" "btservices" "ondevicepersonalization" "uwb"
+      ] ++ lib.optionals (config.androidVersion >= 14) [
+        "configinfrastructure" "devicelock" "healthfitness" "rkpd"
+        "hardware.cas"
       ]
     );
 


### PR DESCRIPTION
Depends on https://github.com/nix-community/robotnix/pull/259

Makes the signing script work again with Android 13. Tested with yet unmerged lineage-21.0 build. Also tested signing scripts work for Android 13 (especially the APEX part), although I didn't test flashing that image