### PR TITLE
lineageos: allow prebuilt webview

### DIFF
--- a/flavors/lineageos/default.nix
+++ b/flavors/lineageos/default.nix
@@ -156,18 +156,15 @@ in mkIf (config.flavor == "lineageos")
   source.manifest.url = mkDefault "https://github.com/LineageOS/android.git";
   source.manifest.rev = mkDefault "refs/heads/${LineageOSRelease}";
 
-  # Enable robotnix-built chromium / webview
-  apps.chromium.enable = mkDefault true;
-  webview.chromium.availableByDefault = mkDefault true;
-  webview.chromium.enable = mkDefault true;
-
-  # This is the prebuilt webview apk from LineageOS. Adding this here is only
-  # for convenience if the end-user wants to set `webview.prebuilt.enable = true;`.
+  # This is the prebuilt webview apk from LineageOS. This is the only working
+  # webview we have access to (robotnix' own are in disrepair), so this should
+  # be used by default unless the user provides another webview themselves.
   webview.prebuilt.apk = if config.androidVersion >= 11 then
     config.source.dirs."external/chromium-webview/prebuilt/${config.arch}".src + "/webview.apk"
   else
     config.source.dirs."external/chromium-webview".src + "/prebuilt/${config.arch}/webview.apk";
   webview.prebuilt.availableByDefault = mkDefault true;
+  webview.prebuilt.enable = mkDefault true;
   removedProductPackages = [ "webview" ];
 
   apps.updater.flavor = mkDefault "lineageos";

--- a/modules/webview.nix
+++ b/modules/webview.nix
@@ -75,6 +75,8 @@ in
       # Don't generate a cert if it's the prebuilt version from upstream
       certificate = if (name != "prebuilt") then "${name}webview" else "PRESIGNED";
 
+      usesOptionalLibraries = [ "androidx.window.extensions" ];
+
       # Extra stuff from the Android.mk from the example webview module in AOSP. Unsure if these are needed.
       extraConfig = ''
         LOCAL_MULTILIB := both


### PR DESCRIPTION
We don't have a working webview which would mean you'd need to install one
yourself at runtime. LOS ships a prebuilt webview, let's simply use that.

Fixes https://github.com/nix-community/robotnix/issues/246