### PR TITLE
Handle the NIX_REMOTE=daemon case in `get_store_path`

### DIFF
--- a/scripts/robotnix_common.py
+++ b/scripts/robotnix_common.py
@@ -34,7 +34,7 @@ def get_store_path(path):
     """Get actual path to a Nix store path; supports handling local remotes"""
     prefix = os.getenv("NIX_REMOTE")
 
-    if not prefix:
+    if not prefix or prefix == "daemon":
         return path
 
     prefix = Path(prefix)


### PR DESCRIPTION
As the title says. Previously, the script assumed that the path was not absolute and errored out because of this.