### PR TITLE
fix: Lineage OS  boot animation patch version selection

### DIFF
--- a/flavors/lineageos/default.nix
+++ b/flavors/lineageos/default.nix
@@ -63,7 +63,7 @@ in mkIf (config.flavor == "lineageos") {
 
       (pkgs.replaceVars (if lib.versionAtLeast config.flavorVersion "22.2"
         then ./0002-bootanimation-Reproducibility-fix-22_2.patch
-        else if lib.versionAtLeast config.flavorVersion "21.1"
+        else if lib.versionAtLeast config.flavorVersion "21.0"
         then ./0002-bootanimation-Reproducibility-fix-21.patch else
         ./0002-bootanimation-Reproducibility-fix.patch) {
         inherit (pkgs) imagemagick;


### PR DESCRIPTION
Solve #309

By fixing Lineage minimum version from 21.1 to 21.0 in boot animation patch selection